### PR TITLE
Fix parseFlag to honor single-dash short flags like -h

### DIFF
--- a/src/scripts/cli-options.ts
+++ b/src/scripts/cli-options.ts
@@ -1,5 +1,8 @@
 export function parseFlag(args: string[], flag: string): boolean {
-    return args.includes(`--${flag}`);
+    if (args.includes(`--${flag}`)) return true;
+    // Allow single-dash short form (e.g. `-h`) for single-character flags only,
+    // so long flags like `--help` aren't accidentally matched as `-help`.
+    return flag.length === 1 && args.includes(`-${flag}`);
 }
 
 export function parseOption(args: string[], flag: string): string | undefined {

--- a/tests/CliOptions.test.ts
+++ b/tests/CliOptions.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { parseFlag, parseOption, parseMultiOption } from '../src/scripts/cli-options.js';
+
+describe('parseFlag', () => {
+    it('matches long form --flag', () => {
+        assert.strictEqual(parseFlag(['--help'], 'help'), true);
+        assert.strictEqual(parseFlag(['--TMDirectory', './x', '--generatePDF'], 'generatePDF'), true);
+    });
+
+    it('matches single-dash short form for single-character flags', () => {
+        assert.strictEqual(parseFlag(['-h'], 'h'), true);
+        assert.strictEqual(parseFlag(['some-arg', '-h'], 'h'), true);
+    });
+
+    it('does not match single-dash form for multi-character flags', () => {
+        // Avoid matching `-help` as if it were `--help` to prevent ambiguity
+        // with bundled short flags or unrelated arguments.
+        assert.strictEqual(parseFlag(['-help'], 'help'), false);
+        assert.strictEqual(parseFlag(['-generatePDF'], 'generatePDF'), false);
+    });
+
+    it('returns false when flag is absent', () => {
+        assert.strictEqual(parseFlag(['--other'], 'help'), false);
+        assert.strictEqual(parseFlag([], 'h'), false);
+    });
+});
+
+describe('parseOption', () => {
+    it('returns the value following --flag', () => {
+        assert.strictEqual(parseOption(['--TMDirectory', './path'], 'TMDirectory'), './path');
+    });
+
+    it('returns undefined when flag is missing', () => {
+        assert.strictEqual(parseOption(['--other', 'val'], 'TMDirectory'), undefined);
+    });
+
+    it('returns undefined when next arg is itself a flag', () => {
+        assert.strictEqual(parseOption(['--TMDirectory', '--other'], 'TMDirectory'), undefined);
+    });
+
+    it('returns undefined when --flag is the last argument', () => {
+        assert.strictEqual(parseOption(['--TMDirectory'], 'TMDirectory'), undefined);
+    });
+});
+
+describe('parseMultiOption', () => {
+    it('collects values from repeated --flag value pairs', () => {
+        assert.deepStrictEqual(
+            parseMultiOption(['--assetFolder', 'a', '--assetFolder', 'b'], 'assetFolder'),
+            ['a', 'b'],
+        );
+    });
+
+    it('supports --flag=value syntax', () => {
+        assert.deepStrictEqual(
+            parseMultiOption(['--assetFolder=a', '--assetFolder=b'], 'assetFolder'),
+            ['a', 'b'],
+        );
+    });
+
+    it('splits comma-separated values and trims whitespace', () => {
+        assert.deepStrictEqual(
+            parseMultiOption(['--assetFolder', 'a, b , c'], 'assetFolder'),
+            ['a', 'b', 'c'],
+        );
+    });
+
+    it('returns empty array when flag is absent', () => {
+        assert.deepStrictEqual(parseMultiOption(['--other', 'x'], 'assetFolder'), []);
+    });
+});


### PR DESCRIPTION
## Summary

`-h` is documented in the help output of several CLI scripts (`verify-threat-model`, `build-mkdocs-site`, `build-threat-model-directory`, `build-astro-site`, etc.) but the shared `parseFlag` helper only matched `--<flag>`. Hitting `-h` gave an unrelated error instead of the help screen.

### Repro

```
$ npx tsx src/scripts/verify-threat-model.ts -h
Verification failed: File not found: /.../threat-model-tool/-h
```

The help text claims this is supported:

```
Options:
  --TMDirectory <path>   Directory containing TM sub-folders (<name>/<name>.yaml)
  --help, -h             Show this help
```

### Fix

In `src/scripts/cli-options.ts`, allow `parseFlag` to also match `-<flag>` when the flag name is a single character. Long flags like `--help` and `--generatePDF` are not ambiguously matched as `-help` / `-generatePDF` because the short form is gated on `flag.length === 1`.

After the fix:

```
$ npx tsx src/scripts/verify-threat-model.ts -h
Usage:
  verify-threat-model <yamlFile>
  verify-threat-model --TMDirectory <path>
...
```

## Test plan

- [x] New unit test suite `tests/CliOptions.test.ts` covering `parseFlag`, `parseOption`, `parseMultiOption` (long form, single-dash short form for single-char flags, rejection of `-help` for multi-char flags, missing flags, repeated flags, `--flag=value` form, comma-separated values).
- [x] `npm run compile` clean.
- [x] `npm run build` clean.
- [x] `npm test` passes (58/58, including the 12 new assertions).
- [x] `npm run verify:examples` succeeds (3 succeeded, 0 failed).
- [x] Manually confirmed `-h` and `--help` both render help text on `verify-threat-model.ts` and `build-mkdocs-site.ts`.