### PR TITLE
Fix CVSS score line duplicating the score number in MarkdownRenderer

### DIFF
--- a/src/renderers/MarkdownRenderer.ts
+++ b/src/renderers/MarkdownRenderer.ts
@@ -107,9 +107,9 @@ export class MarkdownRenderer {
         md += `**Type:** ${threat.threatType}\n\n`;
         
         if (threat.cvssObject) {
-            const scoreDesc = threat.getSmartScoreDesc();
-            const scoreVal = threat.getSmartScoreVal();
-            md += `**CVSS Score:** ${scoreVal.toFixed(1)} (${scoreDesc})\n\n`;
+            // getSmartScoreDesc() already returns "<score> (<severity>)" (e.g. "7.5 (High)")
+            // or "TODO CVSS" when unset, so render it directly without re-wrapping.
+            md += `**CVSS Score:** ${threat.getSmartScoreDesc()}\n\n`;
         }
 
         if (threat.attack) {

--- a/tests/ThreatModel.test.ts
+++ b/tests/ThreatModel.test.ts
@@ -77,9 +77,28 @@ test('Markdown Rendering', async (t) => {
         const tm = new ThreatModel(path.join(examplesDir, 'Example2/Example2.yaml'));
         const renderer = new MarkdownRenderer(tm);
         const summary = renderer.renderSummary();
-        
+
         assert.ok(summary.includes('Summary'), 'Summary should have title');
         assert.ok(summary.includes('Total Threats'), 'Summary should have threat count');
+    });
+
+    await t.test('CVSS score line is not duplicated', () => {
+        // Regression: getSmartScoreDesc() already returns "<score> (<severity>)",
+        // so the renderer must not wrap it again ("7.5 (7.5 (High))").
+        const tm = new ThreatModel(path.join(examplesDir, 'Example2/Example2.yaml'));
+        const markdown = new MarkdownRenderer(tm).renderFullReport();
+        const cvssLines = markdown
+            .split('\n')
+            .filter(line => line.startsWith('**CVSS Score:**'));
+
+        assert.ok(cvssLines.length > 0, 'Example2 should produce at least one CVSS line');
+        for (const line of cvssLines) {
+            assert.doesNotMatch(
+                line,
+                /\(\s*\d+(\.\d+)?\s*\(/,
+                `CVSS line should not contain a nested score: ${line}`,
+            );
+        }
     });
 });
 


### PR DESCRIPTION
## Summary

`MarkdownRenderer.renderThreat` produces a malformed CVSS line that prints the numeric score twice:

```
**CVSS Score:** 7.5 (7.5 (High))
```

`Threat.getSmartScoreDesc()` already returns the fully formatted string `"<score> (<severity>)"` (e.g. `"7.5 (High)"`), or `"TODO CVSS"` when the score is unset. The renderer was wrapping that string with `\${scoreVal.toFixed(1)} (\${scoreDesc})`, producing the nested duplicate.

### Repro (before the fix)

```js
const tm = new ThreatModel('tests/exampleThreatModels/Example2/Example2.yaml');
console.log(new MarkdownRenderer(tm).renderFullReport()
  .split('\n').filter(l => l.includes('CVSS')).join('\n'));
// **CVSS Score:** 7.5 (7.5 (High))
// **CVSS Score:** 7.5 (7.5 (High))
```

### After the fix

```
**CVSS Score:** 7.5 (High)
**CVSS Score:** 7.5 (High)
```

This affects any consumer of `MarkdownRenderer.renderFullReport()` and, transitively, `PDFRenderer` (which calls it on lines 94 and 128).

## Test plan

- [x] New regression assertion in `Markdown Rendering` suite verifying no rendered CVSS line contains a nested numeric score (matches `\(\s*\d+(\.\d+)?\s*\(`).
- [x] `npm run compile` clean.
- [x] `npm run build` clean.
- [x] `npm test` passes (47/47, including the new assertion).
- [x] Manual repro: before the fix, the new test fails with `\`**CVSS Score:** 7.5 (7.5 (High))\``; after the fix it passes.