### PR TITLE
Fix TMCVSS.clean_vector to actually strip the CVSS:x.x/ prefix

### DIFF
--- a/src/models/CVSS.ts
+++ b/src/models/CVSS.ts
@@ -144,9 +144,16 @@ export class TMCVSS {
 
     /**
      * Return the vector string without the CVSS:3.x/ prefix, for display.
+     *
+     * Examples:
+     *   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" -> "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+     *   "CVSS:3.0/AV:N/..."                            -> "AV:N/..."
+     *   "AV:N/AC:L/..." (no prefix)                    -> "AV:N/AC:L/..." (unchanged)
      */
     clean_vector(): string {
         if (!this.vector) return '';
-        return this.vector;
+        if (!this.vector.startsWith('CVSS:')) return this.vector;
+        const slash = this.vector.indexOf('/');
+        return slash >= 0 ? this.vector.slice(slash + 1) : this.vector;
     }
 }

--- a/tests/CVSS.test.ts
+++ b/tests/CVSS.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { TMCVSS } from '../src/models/CVSS.js';
+
+test('TMCVSS.clean_vector', async (t) => {
+    await t.test('strips CVSS:3.1/ prefix', () => {
+        const cvss = new TMCVSS('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H');
+        assert.strictEqual(cvss.clean_vector(), 'AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H');
+    });
+
+    await t.test('strips CVSS:3.0/ prefix', () => {
+        const cvss = new TMCVSS('CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H');
+        assert.strictEqual(cvss.clean_vector(), 'AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H');
+    });
+
+    await t.test('strips unknown CVSS: prefix versions', () => {
+        const cvss = new TMCVSS('CVSS:4.0/AV:N/AC:L');
+        assert.strictEqual(cvss.clean_vector(), 'AV:N/AC:L');
+    });
+
+    await t.test('returns vector unchanged when there is no CVSS: prefix', () => {
+        const cvss = new TMCVSS('AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H');
+        assert.strictEqual(cvss.clean_vector(), 'AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H');
+    });
+
+    await t.test('returns empty string when vector is empty', () => {
+        const cvss = new TMCVSS('');
+        assert.strictEqual(cvss.clean_vector(), '');
+    });
+
+    await t.test('output never starts with the CVSS:x.x/ prefix', () => {
+        for (const v of [
+            'CVSS:3.0/AV:N/AC:L',
+            'CVSS:3.1/AV:N/AC:L',
+            'CVSS:4.0/AV:N/AC:L',
+        ]) {
+            const out = new TMCVSS(v).clean_vector();
+            assert.ok(!out.startsWith('CVSS:'), `clean_vector should drop the CVSS: prefix, got: ${out}`);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

The docstring on \`TMCVSS.clean_vector\` says:

> Return the vector string without the \`CVSS:3.x/\` prefix, for display.

but the implementation just returned \`this.vector\` verbatim. Both the HTML report (\`renderers/lib_py.ts\` → \`<code>\${cvss.clean_vector()}</code>\`) and the Jira ticket creators (\`jira/index.ts\`, \`scripts/create-jira-tickets.ts\`) were therefore rendering the noisy \`CVSS:3.1/AV:N/AC:L/...\` form instead of the intended \`AV:N/AC:L/...\`.

### Before
\`\`\`html
<strong>Vector:</strong><code>CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H</code>
\`\`\`

### After
\`\`\`html
<strong>Vector:</strong><code>AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H</code>
\`\`\`

## Fix

Strip the prefix up to and including the first \`/\` whenever the vector starts with \`CVSS:\` (covers 3.0, 3.1, and any future 3.x / 4.x). Vectors without the prefix and the empty string are returned unchanged.

## Tests

New \`tests/CVSS.test.ts\` exercises the six branches:
- strips \`CVSS:3.1/\` prefix
- strips \`CVSS:3.0/\` prefix
- strips unknown-version \`CVSS:4.0/\` prefix
- returns vector unchanged when there is no \`CVSS:\` prefix
- returns empty string when vector is empty
- output never starts with \`CVSS:\`

\`npm test\` and \`npm run compile\` both clean.

\`\`\`
# tests 81
# pass 81
# fail 0
\`\`\`