### PR TITLE
Fix MarkdownRenderer.renderSummary to bucket threats by severity, not score

### DIFF
--- a/src/models/Threat.ts
+++ b/src/models/Threat.ts
@@ -159,6 +159,15 @@ export default class Threat extends BaseThreatModelObject {
         return this.cvssObject ? this.cvssObject.getSmartScoreColor() : 'gray';
     }
 
+    /**
+     * Severity bucket only ("Low" / "Medium" / "High" / "Critical" / "None"),
+     * without the numeric score. Use this when grouping or aggregating threats
+     * by severity; use `getSmartScoreDesc()` for full per-threat display strings.
+     */
+    getSmartScoreSeverity(): string {
+        return this.cvssObject ? this.cvssObject.getSmartScoreSeverity() : 'TODO CVSS';
+    }
+
     /** Mitigation status text matching Python output */
     statusDefaultText(): string {
         if (this.fullyMitigated) {

--- a/src/renderers/MarkdownRenderer.ts
+++ b/src/renderers/MarkdownRenderer.ts
@@ -173,15 +173,29 @@ export class MarkdownRenderer {
         md += `- **Fully Mitigated Threats:** ${mitigatedThreats}\n`;
         md += `- **Unmitigated Threats:** ${this.threatModel.threats.length - mitigatedThreats}\n\n`;
 
+        // Group by severity bucket only (Critical/High/Medium/Low/None/TODO CVSS),
+        // not by the full "<score> (<severity>)" description — otherwise every
+        // distinct numeric score becomes its own bucket and the breakdown is
+        // useless on any model with more than a handful of threats.
+        const severityOrder = ['Critical', 'High', 'Medium', 'Low', 'None', 'TODO CVSS'];
         const severityCounts: Record<string, number> = {};
         for (const threat of this.threatModel.threats) {
-            const severity = threat.getSmartScoreDesc();
+            const severity = threat.getSmartScoreSeverity();
             severityCounts[severity] = (severityCounts[severity] || 0) + 1;
         }
 
         md += `**Threat Severity Breakdown:**\n`;
+        const seen = new Set<string>();
+        for (const severity of severityOrder) {
+            if (severityCounts[severity]) {
+                md += `- ${severity}: ${severityCounts[severity]}\n`;
+                seen.add(severity);
+            }
+        }
         for (const [severity, count] of Object.entries(severityCounts)) {
-            md += `- ${severity}: ${count}\n`;
+            if (!seen.has(severity)) {
+                md += `- ${severity}: ${count}\n`;
+            }
         }
         md += `\n`;
 

--- a/tests/MarkdownRendererSummary.test.ts
+++ b/tests/MarkdownRendererSummary.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ThreatModel from '../src/models/ThreatModel.js';
+import { MarkdownRenderer } from '../src/renderers/MarkdownRenderer.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const examplesDir = path.join(__dirname, 'exampleThreatModels');
+
+test('MarkdownRenderer.renderSummary groups threats by severity bucket', async (t) => {
+    const tm = new ThreatModel(path.join(examplesDir, 'FullFeature/FullFeature.yaml'));
+    const summary = new MarkdownRenderer(tm).renderSummary();
+
+    await t.test('does not bucket by numeric score', () => {
+        // Pre-fix output looked like "- 7.5 (High): 1\n- 9.8 (Critical): 1\n- 5.4 (Medium): 1...".
+        // The grouping key now should be the severity bucket only.
+        const numericBucket = summary.match(/^- \d/m);
+        assert.strictEqual(
+            numericBucket,
+            null,
+            `Severity breakdown lines should not start with a numeric score, got line: ${numericBucket}`
+        );
+    });
+
+    await t.test('uses severity-only bucket names', () => {
+        const allowed = ['Critical', 'High', 'Medium', 'Low', 'None', 'TODO CVSS'];
+        const breakdownLines = summary
+            .split('\n')
+            .filter(line => line.startsWith('- ') && line.includes(':'));
+        // After the "Severity Breakdown" heading, every bullet's key must be one of the allowed bucket names.
+        const heading = summary.indexOf('**Threat Severity Breakdown:**');
+        assert.ok(heading >= 0, 'Severity Breakdown heading should be present');
+        const tail = summary.slice(heading);
+        for (const line of tail.split('\n').filter(l => l.startsWith('- '))) {
+            const key = line.slice(2, line.indexOf(':')).trim();
+            assert.ok(
+                allowed.includes(key),
+                `Bucket name "${key}" should be one of ${allowed.join(', ')} (line: ${line})`
+            );
+        }
+        assert.ok(breakdownLines.length > 0, 'Should emit at least one breakdown line');
+    });
+
+    await t.test('a single bucket aggregates all threats sharing that severity', () => {
+        // Count "High" threats in the underlying model and compare to the summary line.
+        const expectedHigh = tm.threats.filter(t => t.getSmartScoreSeverity() === 'High').length;
+        if (expectedHigh === 0) return;
+        const match = summary.match(/- High:\s+(\d+)/);
+        assert.ok(match, 'Should emit a "High:" bucket line when High-severity threats exist');
+        assert.strictEqual(
+            Number(match![1]),
+            expectedHigh,
+            `Summary should report ${expectedHigh} High-severity threats`
+        );
+    });
+});


### PR DESCRIPTION
## Summary

The "Threat Severity Breakdown" section in \`MarkdownRenderer.renderSummary()\` was keying its counts on \`threat.getSmartScoreDesc()\`, which returns the full formatted string \`"<score> (<severity>)"\` — so each unique numeric score produced its own bucket. On any model with more than a handful of threats the breakdown ends up as one bullet per threat rather than the intended bucket counts.

### Before
\`\`\`
**Threat Severity Breakdown:**
- 9.8 (Critical): 1
- 7.5 (High): 1
- 6.7 (Medium): 1
- 6.5 (Medium): 1
- 4.3 (Medium): 1
...
\`\`\`

### After
\`\`\`
**Threat Severity Breakdown:**
- Critical: 1
- High: 3
- Medium: 4
- Low: 2
\`\`\`

## Changes

- **\`src/renderers/MarkdownRenderer.ts\`** — group on the severity bucket only, render in a fixed order (Critical → High → Medium → Low → None → TODO CVSS) and emit any unknown bucket label after that so nothing is silently dropped.
- **\`src/models/Threat.ts\`** — add a \`getSmartScoreSeverity()\` proxy that defers to the underlying \`TMCVSS.getSmartScoreSeverity()\` (which already exists) so the renderer does not have to reach into the CVSS object directly. The proxy matches the shape of the existing \`getSmartScoreDesc/Val/Color\` proxies.

## Tests

New \`tests/MarkdownRendererSummary.test.ts\` covers:
- breakdown lines do not start with a numeric score
- every bucket key is one of \`Critical\` / \`High\` / \`Medium\` / \`Low\` / \`None\` / \`TODO CVSS\`
- the \`High\` bucket count matches the count of \`High\` threats in the underlying model

\`npm test\` and \`npm run compile\` both clean.