### PR TITLE
Fix PlantUMLRenderer using full score description as severity stereotype

### DIFF
--- a/src/renderers/PlantUMLRenderer.ts
+++ b/src/renderers/PlantUMLRenderer.ts
@@ -24,11 +24,20 @@ export class PlantUMLRenderer {
         puml += '  BorderColor Black\n';
         puml += '}\n\n';
 
-        // Render threats as rectangles
+        // Render threats as rectangles.
+        //
+        // The `<<...>>` stereotype must match the keys declared in the
+        // `skinparam rectangle` block above ("Critical" / "High" / "Medium" /
+        // "Low" / "None"), otherwise PlantUML falls back to the default colour
+        // and the severity heatmap is lost. Previously this code used
+        // `getSmartScoreDesc()` (e.g. "9.8 (Critical)") as both the stereotype
+        // and the CVSS line, which broke the heatmap and printed the numeric
+        // score twice on the CVSS line. Use the severity bucket alone for the
+        // stereotype and compose the CVSS line from the score plus severity.
         for (const threat of this.threatModel.threats) {
-            const severity = threat.getSmartScoreDesc();
+            const severity = threat.cvssObject ? threat.cvssObject.getSmartScoreSeverity() : 'TODO CVSS';
             const score = threat.getSmartScoreVal().toFixed(1);
-            
+
             puml += `rectangle "${this.escapePlantUML(threat.title || threat.id)}" as ${threat.id} <<${severity}>> {\n`;
             puml += `  **Type:** ${this.escapePlantUML(threat.threatType || '')}\n`;
             puml += `  **CVSS:** ${score} (${severity})\n`;

--- a/tests/ThreatModel.test.ts
+++ b/tests/ThreatModel.test.ts
@@ -93,10 +93,43 @@ test('PlantUML Rendering', async (t) => {
         const tm = new ThreatModel(path.join(examplesDir, 'Example2/Example2.yaml'));
         const renderer = new PlantUMLRenderer(tm);
         const puml = renderer.renderThreatDiagram();
-        
+
         assert.ok(puml.startsWith('@startuml'), 'PlantUML should start with @startuml');
         assert.ok(puml.endsWith('@enduml\n'), 'PlantUML should end with @enduml');
         assert.ok(puml.includes('rectangle'), 'PlantUML should have rectangles');
+    });
+
+    await t.test('threat rectangles use the severity bucket as stereotype, not the full score description', () => {
+        // Regression: renderThreatDiagram() previously used getSmartScoreDesc()
+        // for both the <<...>> stereotype and the CVSS line, producing
+        // `<<7.5 (High)>>` rectangles (which never match the
+        // skinparam keys "<<Critical>>" / "<<High>>" / ... so the colour
+        // heatmap silently disappeared) and a doubled `**CVSS:** 7.5 (7.5 (High))`
+        // line.
+        const tm = new ThreatModel(path.join(examplesDir, 'Example2/Example2.yaml'));
+        const puml = new PlantUMLRenderer(tm).renderThreatDiagram();
+
+        assert.ok(tm.threats.length > 0, 'fixture must contain at least one threat');
+
+        // No numeric-prefixed stereotype like `<<7.5 (High)>>`.
+        assert.ok(
+            !/<<\s*\d/.test(puml),
+            `stereotype must be the severity bucket only, got:\n${puml}`,
+        );
+
+        // At least one of the canonical severity stereotypes from the
+        // skinparam block must appear.
+        const canonical = ['<<Critical>>', '<<High>>', '<<Medium>>', '<<Low>>', '<<None>>'];
+        assert.ok(
+            canonical.some((s) => puml.includes(s)),
+            `expected at least one canonical severity stereotype, got:\n${puml}`,
+        );
+
+        // CVSS line must not duplicate the numeric score.
+        assert.ok(
+            !/\*\*CVSS:\*\*\s+\d+(?:\.\d+)?\s+\(\d/.test(puml),
+            `CVSS line should be "score (Severity)", not "score (score (Severity))":\n${puml}`,
+        );
     });
 
     await t.test('should render security objectives diagram', () => {


### PR DESCRIPTION
## Summary

`PlantUMLRenderer.renderThreatDiagram` used `Threat.getSmartScoreDesc()` — which returns the full formatted string \"`<score> (<severity>)`\", e.g. `7.5 (High)` — in two places where it should have used the severity bucket alone.

### Bug 1 — broken severity heatmap

The rectangle's `<<...>>` stereotype was emitted as the full score description:

```
rectangle "Threat title" as DATA_EXPOSURE <<7.5 (High)>> {
```

The `skinparam rectangle` block above only registers the canonical buckets:

```
BackgroundColor<<Critical>> #cc0500
BackgroundColor<<High>>     #df3d03
BackgroundColor<<Medium>>   #f9a009
BackgroundColor<<Low>>      #ffcb0d
BackgroundColor<<None>>     #53aa33
```

A stereotype like `<<7.5 (High)>>` never matches `<<High>>`, so PlantUML falls back to the default colour and the severity heatmap is silently lost.

### Bug 2 — duplicated numeric score on the CVSS line

The CVSS detail line composed the score twice:

```
**CVSS:** 7.5 (7.5 (High))
```

`getSmartScoreVal().toFixed(1)` already renders the numeric score, so appending `getSmartScoreDesc()` afterwards repeats it inside the parenthesised severity tag.

## Fix

Pull the severity bucket directly off `TMCVSS.getSmartScoreSeverity()` (falling back to `\"TODO CVSS\"` when the threat has no CVSS object, matching the behaviour of the other `getSmart*` helpers on `Threat`) and use it both for the rectangle stereotype and for the parenthesised tag on the CVSS line.

Same defect class as #43 (MarkdownRenderer CVSS line duplication) and #50 (MarkdownRenderer severity buckets); the renderer was independently re-using `getSmartScoreDesc()` where the severity bucket was wanted.

## Test

`tests/ThreatModel.test.ts` gets a new sub-test under \"PlantUML Rendering\" that asserts:

- the rendered output contains no numeric-prefixed stereotype (`<<7.5 (High)>>`),
- it contains at least one canonical severity stereotype from the `skinparam` block,
- the CVSS line does not duplicate the numeric score.

The new test fails on `main` and passes with this patch.