### PR TITLE
Load .json threat-model files in the ThreatModel constructor

### DIFF
--- a/src/models/ThreatModel.ts
+++ b/src/models/ThreatModel.ts
@@ -26,8 +26,8 @@ export default class ThreatModel extends BaseThreatModelObject {
     schemaVersion: number = 1;
 
     constructor(fileIn: string, parent: ThreatModel | null = null, publicFlag: boolean = false, versionsFilterStr: string | null = null) {
-        const tmDict = fileIn && (fileIn.endsWith('.yaml') || fileIn.endsWith('.yml'))
-            ? ThreatModel.loadYaml(fileIn)
+        const tmDict = fileIn && ThreatModel.isSupportedFile(fileIn)
+            ? ThreatModel.loadFile(fileIn)
             : {};
             
         super(tmDict, parent);
@@ -329,5 +329,36 @@ export default class ThreatModel extends BaseThreatModelObject {
         } catch (error) {
             throw new Error(`Error loading YAML file ${filename}: ${(error as Error).message}`);
         }
+    }
+
+    private static loadJson(filename: string): Record<string, any> {
+        try {
+            const fileContents = fs.readFileSync(filename, 'utf8');
+            return JSON.parse(fileContents) as Record<string, any>;
+        } catch (error) {
+            throw new Error(`Error loading JSON file ${filename}: ${(error as Error).message}`);
+        }
+    }
+
+    /**
+     * Whether a file path looks like one of the supported threat-model formats.
+     * Matches the formats advertised by `loadThreatModel` / `parseThreatModel`
+     * in `src/parser.ts`.
+     */
+    private static isSupportedFile(filename: string): boolean {
+        const lower = filename.toLowerCase();
+        return lower.endsWith('.yaml') || lower.endsWith('.yml') || lower.endsWith('.json');
+    }
+
+    /**
+     * Load a threat model file, routing on the extension. Previously the
+     * constructor only matched `.yaml` / `.yml` and silently produced an
+     * empty model for `.json` inputs, even though `parser.ts` advertises
+     * JSON support.
+     */
+    private static loadFile(filename: string): Record<string, any> {
+        return filename.toLowerCase().endsWith('.json')
+            ? ThreatModel.loadJson(filename)
+            : ThreatModel.loadYaml(filename);
     }
 }

--- a/tests/ThreatModelJsonFormat.test.ts
+++ b/tests/ThreatModelJsonFormat.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ThreatModel from '../src/models/ThreatModel.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixturePath = path.join(__dirname, 'fixtures', 'json-format.json');
+
+// parser.ts already advertises JSON support (`Unsupported file format. Please
+// provide a YAML or JSON file.`), but the ThreatModel constructor previously
+// only matched .yaml / .yml when deciding whether to read the file. A .json
+// input therefore produced a silent empty model: the early return at the
+// `if (!tmDict.ID)` guard ran without warning.
+test('ThreatModel loads .json files with the same shape as .yaml', () => {
+    const tm = new ThreatModel(fixturePath);
+
+    assert.equal(tm._id, 'json-format', 'ID must be parsed from the JSON document');
+    assert.equal(tm.schemaVersion, 2, 'schemaVersion must come through');
+    assert.equal(tm.threats.length, 1, 'threats must be populated');
+
+    const [threat] = tm.threats;
+    assert.equal(threat.id, 'JSON_THREAT');
+    assert.equal(threat.threatType, 'Information Disclosure');
+    assert.ok(threat.cvssObject, 'CVSS object must be constructed from the JSON dict');
+    assert.equal(threat.countermeasures.length, 1, 'countermeasure must be parsed');
+});

--- a/tests/fixtures/json-format.json
+++ b/tests/fixtures/json-format.json
@@ -1,0 +1,46 @@
+{
+  "ID": "json-format",
+  "schemaVersion": 2,
+  "title": "JSON Format Smoke Test",
+  "version": "1.0",
+  "scope": {
+    "description": "Minimal threat model written in JSON to verify ThreatModel honors the .json extension advertised by parser.ts.",
+    "securityObjectives": [
+      {
+        "ID": "JSON_CONFIDENTIALITY",
+        "title": "JSON Confidentiality",
+        "description": "Prevent unauthorized disclosure.",
+        "group": "Data Security"
+      }
+    ],
+    "attackers": [
+      {
+        "ID": "JSON_ATTACKER",
+        "description": "Unauthenticated external user.",
+        "inScope": true
+      }
+    ]
+  },
+  "threats": [
+    {
+      "ID": "JSON_THREAT",
+      "title": "JSON Threat",
+      "attack": "An attacker accesses sensitive data through a misconfigured access control.",
+      "threatType": "Information Disclosure",
+      "impactDesc": "Sensitive data is disclosed.",
+      "impactedSecObj": [{ "REFID": "JSON_CONFIDENTIALITY" }],
+      "attackers": [{ "REFID": "JSON_ATTACKER" }],
+      "CVSS": { "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N" },
+      "fullyMitigated": false,
+      "countermeasures": [
+        {
+          "ID": "JSON_ACCESS_CONTROL",
+          "title": "Enforce Access Control",
+          "description": "Require authentication and authorization checks on all data access paths.",
+          "inPlace": false,
+          "public": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

`src/parser.ts` advertises JSON support in both `loadThreatModel()` and `parseThreatModel()` — the error message reads:

> Unsupported file format. Please provide a YAML or JSON file.

and `loadThreatModel()` routes any file extension to `new ThreatModel(filePath)`. However, the `ThreatModel` constructor only branched on `.yaml` / `.yml` and silently fell back to `{}` for every other extension, including `.json`:

```ts
const tmDict = fileIn && (fileIn.endsWith('.yaml') || fileIn.endsWith('.yml'))
    ? ThreatModel.loadYaml(fileIn)
    : {};
```

The early-return at the `if (!tmDict.ID)` guard a few lines below then produced an empty model with no warning, leaving every downstream caller — `verify-threat-model`, `build-mkdocs-site`, `build-astro-site`, `ReportGenerator` — to operate on an empty threat list.

## Fix

Route on the extension via small `isSupportedFile` / `loadFile` helpers so the format list lives in one place. JSON is parsed with `JSON.parse` (parallel to the existing YAML loader, which uses `js-yaml`). Errors are wrapped with the filename for symmetry with `loadYaml`.

The child-model discovery code at the bottom of the constructor still looks up `${REFID}.yaml` only — the parent/child REFID lookup already assumes that layout, and extending it to JSON would broaden the diff. This change only unblocks a JSON file passed as the top-level input that `parser.ts` already promises to accept.

## Test

`tests/fixtures/json-format.json` is a minimal threat model in JSON form. `tests/ThreatModelJsonFormat.test.ts` asserts that a `.json` input produces the expected `ID`, `schemaVersion`, threats, and countermeasures. The new test fails on `main` and passes with this patch.