### PR TITLE
Run puppeteer docker call as argv list to remove shell injection from headerNote

### DIFF
--- a/src/renderers/PDFRenderer.ts
+++ b/src/renderers/PDFRenderer.ts
@@ -1,11 +1,41 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import ThreatModel from '../models/ThreatModel.js';
 import { MarkdownRenderer } from './MarkdownRenderer.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+/**
+ * Build the argv list for the puppeteer-in-docker call used by
+ * `PDFRenderer.renderToPDF`. Exported separately so the argv composition can
+ * be unit-tested without spawning docker: each substituted value (mount path,
+ * output paths, header note) is passed as a discrete argv entry to
+ * `execFileSync`, so shell metacharacters cannot escape the call.
+ */
+export function buildPuppeteerDockerArgs(params: {
+    tempScriptsDir: string;
+    outputDir: string;
+    containerUser: string;
+    image: string;
+    htmlFileName: string;
+    fileName: string;
+    headerNote: string;
+}): string[] {
+    const { tempScriptsDir, outputDir, containerUser, image, htmlFileName, fileName, headerNote } = params;
+    return [
+        'run', '--init', '--cap-add=SYS_ADMIN',
+        '-v', `${path.resolve(tempScriptsDir)}:${containerUser}/scripts`,
+        '-v', `${path.resolve(outputDir)}:${containerUser}/output`,
+        '-w', containerUser,
+        '--rm', image,
+        'node', 'scripts/pdfScript.mjs',
+        `file://${containerUser}/output/${htmlFileName}`,
+        `${containerUser}/output/${fileName}`,
+        headerNote,
+    ];
+}
 
 export class PDFRenderer {
     private threatModel: ThreatModel;
@@ -61,18 +91,26 @@ export class PDFRenderer {
             : 'ghcr.io/puppeteer/puppeteer:latest';
         const containerUser = isArm64 ? '/usr/src/app' : '/home/pptruser';
 
-        const dockerCommand = `docker run --init --cap-add=SYS_ADMIN ` +
-            `-v "${path.resolve(tempScriptsDir)}:${containerUser}/scripts" ` +
-            `-v "${path.resolve(outputDir)}:${containerUser}/output" ` +
-            `-w "${containerUser}" ` +
-            `--rm ${image} ` +
-            `node scripts/pdfScript.mjs ` +
-            `"file://${containerUser}/output/${htmlFileName}" ` +
-            `"${containerUser}/output/${fileName}" ` +
-            `"${headerNote.replace(/"/g, '\\"')}"`;
+        // Build the docker invocation as an explicit argv list and run it
+        // without a shell. Previously this was a single command string passed
+        // to execSync, with only `"` escaped on headerNote — `$(...)`,
+        // backticks, `;`, and `&&` in any of the substituted values would
+        // still execute against the host shell. Using execFileSync with a
+        // string array bypasses the shell entirely and removes the injection
+        // surface for callers that route untrusted strings through
+        // `options.headerNote` or the resolved paths.
+        const dockerArgs = buildPuppeteerDockerArgs({
+            tempScriptsDir,
+            outputDir,
+            containerUser,
+            image,
+            htmlFileName,
+            fileName,
+            headerNote,
+        });
 
         try {
-            execSync(dockerCommand, { stdio: 'inherit', timeout: 300000 });
+            execFileSync('docker', dockerArgs, { stdio: 'inherit', timeout: 300000 });
             console.log(`PDF generated successfully: ${outputPath}`);
         } catch (error) {
             throw new Error(`Docker PDF generation failed: ${(error as Error).message}`);

--- a/tests/PDFRendererArgs.test.ts
+++ b/tests/PDFRendererArgs.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import path from 'node:path';
+import { buildPuppeteerDockerArgs } from '../src/renderers/PDFRenderer.js';
+
+// PDFRenderer.renderToPDF used to compose a single shell-string command and
+// hand it to execSync with only the `"` character escaped on headerNote.
+// `$(...)`, backticks, `;`, `&&`, and similar metacharacters in the
+// headerNote (or in the resolved mount paths) would still be interpreted by
+// the host shell.
+//
+// The renderer now builds an explicit argv list and runs it via execFileSync,
+// which spawns docker directly with no shell in between. This test pins that
+// behaviour by asserting that:
+//   - the substituted values arrive as their own argv entries (no joining), and
+//   - the headerNote is passed through verbatim regardless of what
+//     metacharacters it contains.
+test('buildPuppeteerDockerArgs keeps headerNote and resolved paths as standalone argv entries', () => {
+    const headerNote = 'Private $(rm -rf ~) `id` & echo PWNED; "Confidential"';
+    const tempScriptsDir = '/tmp/scripts dir';
+    const outputDir = '/tmp/out dir';
+
+    const args = buildPuppeteerDockerArgs({
+        tempScriptsDir,
+        outputDir,
+        containerUser: '/home/pptruser',
+        image: 'ghcr.io/puppeteer/puppeteer:latest',
+        htmlFileName: 'report.html',
+        fileName: 'report.pdf',
+        headerNote,
+    });
+
+    // headerNote is the trailing argv entry and must arrive byte-for-byte.
+    assert.equal(
+        args[args.length - 1],
+        headerNote,
+        'headerNote must round-trip through the argv list without escaping or splitting',
+    );
+
+    // The two -v mount specs must each be a single argv entry, not multiple.
+    const tempIdx = args.indexOf(`${path.resolve(tempScriptsDir)}:/home/pptruser/scripts`);
+    const outIdx = args.indexOf(`${path.resolve(outputDir)}:/home/pptruser/output`);
+    assert.ok(tempIdx > 0, 'tempScriptsDir mount must appear as a single argv entry');
+    assert.ok(outIdx > 0, 'outputDir mount must appear as a single argv entry');
+    assert.equal(args[tempIdx - 1], '-v', '-v flag must precede the temp mount entry');
+    assert.equal(args[outIdx - 1], '-v', '-v flag must precede the output mount entry');
+
+    // No argv entry concatenates the host path with a shell metachar tail —
+    // a smoke test that the old `\` / `"` escaping is gone.
+    for (const a of args) {
+        assert.ok(typeof a === 'string', 'every argv entry must be a string');
+        assert.ok(
+            !a.includes('\\"'),
+            `argv entry should not contain shell-escaped quotes (got: ${a})`,
+        );
+    }
+});


### PR DESCRIPTION
## Summary

`PDFRenderer.renderToPDF` composed a single shell-string `docker run …` command and passed it to `execSync`, escaping only `"` on `options.headerNote`:

```ts
const dockerCommand = `docker run --init … "${headerNote.replace(/"/g, '\\"')}"`;
execSync(dockerCommand, { stdio: 'inherit', timeout: 300000 });
```

`execSync` invokes `/bin/sh -c <string>`. Only `"` was sanitised, so `$(...)`, backticks, `;`, `&&`, `||`, redirections, etc. in `headerNote` (and in the mount paths resolved from `outputPath` / `__dirname`) were still interpreted by the host shell.

`headerNote` is the value of the `--pdfHeaderNote` CLI flag wired through `build-threat-model.ts` and `build-mkdocs-site.ts`. A caller that surfaces an untrusted note (e.g. populated from a YAML config, CI pipeline variable, or user form field) can execute arbitrary commands on the host.

## Fix

Extract the docker invocation into a `buildPuppeteerDockerArgs` helper that returns an explicit `string[]` argv list, and run the list through `execFileSync`. `execFileSync` spawns the binary directly without a shell, so each substituted value travels as its own argv entry; host-shell metacharacters in any of them are inert.

No external-API change. `renderToPDF`'s signature, behaviour on the happy path, and error handling are unchanged.

## Test

`buildPuppeteerDockerArgs` is exported so the argv shape can be pinned without spawning docker. `tests/PDFRendererArgs.test.ts` feeds in a deliberately malicious header note —

```
Private $(rm -rf ~) `id` & echo PWNED; "Confidential"
```

— and asserts that:

- the header note round-trips verbatim as the trailing argv entry, and
- the `-v` mount specs each arrive as a single argv entry (i.e. they were not split on whitespace by accidental shell tokenisation).

`npm test` reports 75 passing across the suite.